### PR TITLE
Update Issue1

### DIFF
--- a/pages/Rlisa33/Issue1
+++ b/pages/Rlisa33/Issue1
@@ -1,7 +1,7 @@
 ### Command prompt opens and starts vagrant every time I turn on my computer. Interns need to avoid this. I reads 
 ### "Starting vagrant in power down state. But later says failure to start vagrant!
-This is very important and can occur because of various reasons.
-*The computer software for vagrant is not installed properly.
-*The computer has not accepted or gave permission to your software download
+_This is very important and can occur because of various reasons._
+* The computer software for vagrant is not installed properly.
+* The computer has not accepted or gave permission to your software download
 * The computer needs to download software required to install vagrant.
 _A Step By Step Process Explains the Confusion with unexplained Opening of Command Prompt when the Windows screen is up!_


### PR DESCRIPTION
I have answer to the questions of interns who constantly get the problem of when Command prompt opens and starts vagrant every time I turn on my computer. Interns need to avoid this. I reads "Starting vagrant in power down state. But later says failure to start vagrant. 
There is a way to avoid this is the computer needs to download software required to install vagrant