### PR TITLE
Solution is to Install Hyper V  Issue1

### DIFF
--- a/pages/Rlisa33/Issue1
+++ b/pages/Rlisa33/Issue1
@@ -5,3 +5,5 @@ This is very important and can occur because of various reasons.
 *The computer has not accepted or gave permission to your software download
 * The computer needs to download software required to install vagrant.
 _A Step By Step Process Explains the Confusion with unexplained Opening of Command Prompt when the Windows screen is up!_
+# You need to install hyper -v in windows 7pro software and up to windows. 8.1. Hyper-V is a server-side application up to Windows 8.1 and upcoming version of Windows 10, which include it in the client, too (as the update of Virtual PC)
+image


### PR DESCRIPTION
 ### The Issue of Vagrant Command Prompt Opening as Soon as Windows Screen Is On!
 ### Command prompt opens and starts vagrant every time I turn on my computer. Interns need to avoid 
###  this. IT reads 
 + ###  "Starting vagrant in power down state. But later says failure to start vagrant!
    _ This is very important and can occur because of various reasons._
  *The computer software for vagrant is not installed properly.
+ Solution
                 * _You need to install hyper -v in windows 7pro software and up to windows. 8.1. Hyper-V is a server-side application up to Windows 8.1 and upcoming version of Windows 10, which include it in the client, too (as the update of Virtual PC)
image_